### PR TITLE
Added retain flag and initial publishing

### DIFF
--- a/include/driveio.h
+++ b/include/driveio.h
@@ -21,4 +21,5 @@ void driveio_loop();
 bool driveio_doorstatuschanged(int* oldStatus, int* newStatus);
 void driveio_setdoorcommand(int Command);
 int driveio_getiostatus(int io);
+int driveio_getcurrentdoorstatus();
 bool driveio_doorcommandactive();

--- a/include/mqtt.h
+++ b/include/mqtt.h
@@ -28,7 +28,7 @@
 /* exports */
 void mqtt_init();
 void mqtt_loop();
-void mqtt_publish(String topic, String payload);
+void mqtt_publish(String topic, String payload, bool retain);
 String mqtt_getcommand();
 int mqtt_getpacketsreceived();
 int mqtt_getpacketssent();

--- a/src/driveio.cpp
+++ b/src/driveio.cpp
@@ -145,3 +145,11 @@ int driveio_getiostatus(int io)
 {
     return digitalRead(io);
 }
+
+/*
+* Returns the current door status 
+*/
+int driveio_getcurrentdoorstatus()
+{
+    return currentDoorStatus;
+}

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -102,7 +102,7 @@ void onTopicControlSetNewDoorStateReceived(const String &payload, const size_t s
  * This function publishes a topic. It passes the parameters without change to the
  * underlying mqtt client but adds a serial print for logging purposes
  */
-void mqtt_publish(String topic, String payload)
+void mqtt_publish(String topic, String payload, bool retain)
 {
     Serial.println("RUN: Publish: set " + topic + " to " + payload);
     mqttClient.publish(topic, payload, false, 0);


### PR DESCRIPTION
The current door state is automatically sent on startup of the controller. This message is also retained when other clients connect to the broker and subscribe this topic.